### PR TITLE
EX-1646: add bigger space at sicherearbeit.at between menu and header img

### DIFF
--- a/src/styles/experiencefragments/experiencefragment_header.scss
+++ b/src/styles/experiencefragments/experiencefragment_header.scss
@@ -16,7 +16,7 @@ header.experiencefragment {
 
   @screen md {
     @apply w-full;
-    padding-top: 18vw;
+    padding-top: 20vw;
   }
 
   .cmp-image {


### PR DESCRIPTION
<img width="1792" alt="Bildschirmfoto 2021-10-15 um 15 03 17" src="https://user-images.githubusercontent.com/12427959/137496457-9d32ce82-7adc-4e78-84e3-3701dfcf1ee0.png">
